### PR TITLE
Bug 1759617: UPSTREAM: 13009: Retry on GetBucketTagging 404 Errors

### DIFF
--- a/aws/awserr.go
+++ b/aws/awserr.go
@@ -40,32 +40,8 @@ func retryOnAwsCode(code string, f func() (interface{}, error)) (interface{}, er
 		var err error
 		resp, err = f()
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == code {
+			if isAWSErr(err, code, "") {
 				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-	return resp, err
-}
-
-// RetryOnAwsCodes retries AWS error codes for one minute
-// Note: This function will be moved out of the aws package in the future.
-func RetryOnAwsCodes(codes []string, f func() (interface{}, error)) (interface{}, error) {
-	var resp interface{}
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-		resp, err = f()
-		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok {
-				for _, code := range codes {
-					if awsErr.Code() == code {
-						return resource.RetryableError(err)
-					}
-				}
 			}
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
This PR is an UPSTREAM commit and duplicates https://github.com/terraform-providers/terraform-provider-aws/pull/13009. It can be safely removed once the upstream PR merges. This also needs to be cherry-picked into the release-2.60.0 branch. 