### PR TITLE
feat/ebs: basic support to create gp3 volumes on EC2

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -400,6 +400,7 @@ func resourceAwsInstance() *schema.Resource {
 								ec2.VolumeTypeStandard,
 								ec2.VolumeTypeIo1,
 								ec2.VolumeTypeGp2,
+								ec2.VolumeTypeGp3,
 								ec2.VolumeTypeSc1,
 								ec2.VolumeTypeSt1,
 							}, false),
@@ -511,6 +512,7 @@ func resourceAwsInstance() *schema.Resource {
 								ec2.VolumeTypeStandard,
 								ec2.VolumeTypeIo1,
 								ec2.VolumeTypeGp2,
+								ec2.VolumeTypeGp3,
 								ec2.VolumeTypeSc1,
 								ec2.VolumeTypeSt1,
 							}, false),
@@ -1835,7 +1837,7 @@ func readBlockDeviceMappingsFromConfig(d *schema.ResourceData, conn *ec2.EC2) ([
 				if iops, ok := bd["iops"].(int); ok && iops > 0 {
 					if ec2.VolumeTypeIo1 == strings.ToLower(v) {
 						// Condition: This parameter is required for requests to create io1
-						// volumes; it is not used in requests to create gp2, st1, sc1, or
+						// volumes; it is not used in requests to create gp2, gp3 (optional), st1, sc1, or
 						// standard volumes.
 						// See: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html
 						ebs.Iops = aws.Int64(int64(iops))

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1130,6 +1130,7 @@ func validateAwsEcsPlacementStrategy(stratType, stratField string) error {
 func validateAwsEmrEbsVolumeType() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
 		"gp2",
+		"gp3",
 		"io1",
 		"standard",
 		"st1",


### PR DESCRIPTION
Add basic support to gp3 volumes on EC2. The full support was introduced on upstream release v3.22.0.

This is a second option, without bump SDK to v1.35.37, as described on the PR https://github.com/openshift/terraform-provider-aws/pull/12

References:
- upstream support starts on release v3.22.0: 
https://github.com/hashicorp/terraform-provider-aws/pull/16517
- change default vol type on openshift installer: 
https://github.com/openshift/installer/pull/5239
